### PR TITLE
Bug fix for non-zero lower bounds on linear gauge.

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,4 +1,4 @@
-# OBD2CAN firmware
+# ShiftX3 firmware
 #
 # Copyright (C) 2016 Autosport Labs
 #
@@ -121,7 +121,7 @@ STREAMSSRC = 	$(CHIBIOS)/os/hal/lib/streams/chprintf.c \
 STREAMSINC = $(CHIBIOS)/os/hal/lib/streams
 
 # Define linker script file here
-LDSCRIPT= $(STARTUPLD)/STM32F072xB.ld
+LDSCRIPT= $(STARTUPLD)/STM32F042x6.ld
 
 # C sources that can be compiled in ARM or THUMB mode depending on the global
 # setting.

--- a/firmware/openocd.cfg
+++ b/firmware/openocd.cfg
@@ -1,5 +1,5 @@
-source [find interface/stlink-v2.cfg]
-source [find target/stm32f0x_stlink.cfg]
+source [find interface/stlink.cfg]
+source [find target/stm32f0x.cfg]
 
 adapter_khz 1000
 

--- a/firmware/shiftx3_api.c
+++ b/firmware/shiftx3_api.c
@@ -168,8 +168,13 @@ static void _update_linear_graph_value(void)
     uint32_t range = high_range - low_range;
 
     uint16_t current_value = g_current_linear_graph_value;
+    uint16_t range_adj_value;
     /* offset to zero */
-    current_value -= low_range;
+    if ( current_value < low_range ) {
+        range_adj_value = 0;
+    } else {
+        range_adj_value = current_value - low_range;
+    }
 
     enum linear_style lstyle = g_linear_graph_config.linear_style;
     enum render_style rstyle = g_linear_graph_config.render_style;
@@ -182,11 +187,11 @@ static void _update_linear_graph_value(void)
     }
     switch (rstyle) {
     case RENDER_STYLE_CENTER:
-        _update_center_graph(current_value, range, threshold, lstyle);
+        _update_center_graph(range_adj_value, range, threshold, lstyle);
         break;
     case RENDER_STYLE_LEFT_RIGHT:
     case RENDER_STYLE_RIGHT_LEFT:
-        _update_linear_graph(current_value, range, threshold, LINEAR_GRAPH_COUNT, LINEAR_GRAPH_OFFSET, lstyle, left_right);
+        _update_linear_graph(range_adj_value, range, threshold, LINEAR_GRAPH_COUNT, LINEAR_GRAPH_OFFSET, lstyle, left_right);
         break;
     default:
         log_info(_LOG_PFX "Invalid render style (%i)\r\n", rstyle);


### PR DESCRIPTION
Fixes an issue caused by configuring the linear gauge with a non-zero lower bound.  In that case there were two problems.  First, any value below the lower bound would be inadvertently flipped to a large positive value due to the use of an unsigned int and the value becoming negative.  Second, the value was adjusted by subtracting the lower bound causing the threshold selection to be incorrect give that the thresholds were not adjusted also.

The code was modified to use the unmodified value when selecting the appropriate threshold, and a new variable was introduced to represent the range adjusted value.  The range adjusted value is clamped to zero (cannot be negative) and is then used for determining which percentage of LEDs should be illuminated.

In addition to the above changes the openocd config was modified to update to the non-deprecated target and interface definitions and the Makefile was updated with the correct linker script.