### PR TITLE
Added ability to set an orientation.

### DIFF
--- a/firmware/shiftx3_api.h
+++ b/firmware/shiftx3_api.h
@@ -46,6 +46,11 @@ enum linear_style {
     LINEAR_STYLE_STEPPED
 };
 
+enum orientation {
+    DISPLAY_BOTTOM = 0,
+    DISPLAY_TOP
+};
+
 /*Linear Graph Configuration */
 #define LINEAR_GRAPH_THRESHOLDS 5
 #define DEFAULT_LINEAR_GRAPH_COLOR_RED  0
@@ -76,10 +81,13 @@ struct LinearGraphThreshold {
 
 #define DEFAULT_BRIGHTNESS              0
 #define DEFAULT_LIGHT_SENSOR_SCALING    51
+#define DISPLAY_ORIENTATIONS            2
+#define DEFAULT_ORIENTATION             DISPLAY_BOTTOM
 
 struct ConfigGroup1 {
     uint8_t brightness;
     uint8_t light_sensor_scaling;
+    enum orientation orientation;
 };
 
 /* API offsets */
@@ -115,8 +123,11 @@ uint8_t get_brightness(void);
 
 uint8_t get_light_sensor_scaling(void);
 
+enum orientation get_orientation(void);
+
 struct LedFlashConfig * get_flash_config(size_t index);
 void set_flash_config(size_t led_index, uint8_t flash_hz);
+
 
 /* Base API functions */
 bool api_is_provisoned(void);

--- a/firmware/system_button.c
+++ b/firmware/system_button.c
@@ -48,9 +48,10 @@ static void _broadcast_button_state(uint8_t button_id, bool pressed)
     CANTxFrame can_stats;
     prepare_can_tx_message(&can_stats, CAN_IDE_EXT, get_can_base_id() + API_ALERT_BUTTON_STATES);
 
+    uint8_t report_id = (get_orientation() == DISPLAY_BOTTOM) ? button_id : BUTTON_COUNT - button_id - 1;
     /* these values reserved for future use */
     can_stats.data8[0] = pressed;
-    can_stats.data8[1] = button_id;
+    can_stats.data8[1] = report_id;
     can_stats.DLC = 2;
     canTransmit(&CAND1, CAN_ANY_MAILBOX, &can_stats, MS2ST(CAN_TRANSMIT_TIMEOUT));
     log_trace(_LOG_PFX "Broadcast button_states\r\n");

--- a/firmware/system_display.c
+++ b/firmware/system_display.c
@@ -80,16 +80,25 @@ struct port_pin {
 };
 
 #define DISPLAY_SEGMENT_COUNT 7
-#define DISPLAY_SEGMENT_MAPPING {{DISPLAY_SEGMENT_A_PORT, DISPLAY_SEGMENT_A_PIN}, \
+#define DISPLAY_SEGMENT_BOTTOM_MAPPING {{DISPLAY_SEGMENT_A_PORT, DISPLAY_SEGMENT_A_PIN}, \
                            {DISPLAY_SEGMENT_B_PORT, DISPLAY_SEGMENT_B_PIN}, \
                            {DISPLAY_SEGMENT_C_PORT, DISPLAY_SEGMENT_C_PIN}, \
                            {DISPLAY_SEGMENT_D_PORT, DISPLAY_SEGMENT_D_PIN}, \
                            {DISPLAY_SEGMENT_E_PORT, DISPLAY_SEGMENT_E_PIN}, \
                            {DISPLAY_SEGMENT_F_PORT, DISPLAY_SEGMENT_F_PIN}, \
                            {DISPLAY_SEGMENT_G_PORT, DISPLAY_SEGMENT_G_PIN}, \
-};
+}
+#define DISPLAY_SEGMENT_TOP_MAPPING {{DISPLAY_SEGMENT_D_PORT, DISPLAY_SEGMENT_D_PIN}, \
+                           {DISPLAY_SEGMENT_E_PORT, DISPLAY_SEGMENT_E_PIN}, \
+                           {DISPLAY_SEGMENT_F_PORT, DISPLAY_SEGMENT_F_PIN}, \
+                           {DISPLAY_SEGMENT_A_PORT, DISPLAY_SEGMENT_A_PIN}, \
+                           {DISPLAY_SEGMENT_B_PORT, DISPLAY_SEGMENT_B_PIN}, \
+                           {DISPLAY_SEGMENT_C_PORT, DISPLAY_SEGMENT_C_PIN}, \
+                           {DISPLAY_SEGMENT_G_PORT, DISPLAY_SEGMENT_G_PIN}, \
+}
 
-static const struct port_pin display_port_mappings[DISPLAY_SEGMENT_COUNT] = DISPLAY_SEGMENT_MAPPING;
+static const struct port_pin display_port_mappings[DISPLAY_ORIENTATIONS][DISPLAY_SEGMENT_COUNT] = 
+    {DISPLAY_SEGMENT_BOTTOM_MAPPING, DISPLAY_SEGMENT_TOP_MAPPING};
 
 #define CHARMAP { \
         {'0',0x7E}, \
@@ -173,11 +182,12 @@ static const struct char_segment character_mappings[] = CHARMAP;
 
 void display_set_segment(const uint8_t digit, const uint8_t segment, const bool enabled)
 {
-    log_trace(_LOG_PFX "set segment %d: %d %d\r\n", digit, segment, enabled);
+    const enum orientation orientation = get_orientation();
+    log_trace(_LOG_PFX "set segment %d: %d %d %d\r\n", digit, segment, enabled, orientation);
     if (segment >= DISPLAY_SEGMENT_COUNT)
         return;
 
-    const struct port_pin *mapping = &display_port_mappings[segment];
+    const struct port_pin *mapping = &display_port_mappings[orientation][segment];
 
     if (enabled) {
         palClearPad(mapping->port, mapping->pin);
@@ -219,7 +229,7 @@ void system_display_init(void)
 
     /* init ports for segments */
     for (size_t i = 0; i < DISPLAY_SEGMENT_COUNT; i++) {
-        const struct port_pin *mapping = &display_port_mappings[i];
+        const struct port_pin *mapping = &display_port_mappings[DISPLAY_BOTTOM][i];
         palSetPadMode(mapping->port, mapping->pin, PAL_MODE_OUTPUT_OPENDRAIN);
     }
 


### PR DESCRIPTION
In the config call you can now pass a third parameter that tells the firmware
the orientation of the ShiftX3.  A value of 0 (the default) indicates the 7-segment
display is on the bottom, a value of 1 indicates it's at the top.  When the device is
inverted and the config is updated accordingly, all linear graph functions, alert led and button locations
retain their user relative ids and behavior.

The only function that doesn't respect the orientation of the device is the set_led api calls.